### PR TITLE
Rating fixed on Watchlist and Favorites view

### DIFF
--- a/src/app/templates/browser/item.tpl
+++ b/src/app/templates/browser/item.tpl
@@ -1,6 +1,6 @@
 <%
     if (typeof image === 'undefined') { var image = images.poster; }
-    if (typeof rating === 'object') { var rating = rating.percentage /10; }
+    if (typeof rating === 'object') { var rating = Math.round(rating.percentage) /10; }
 %>
 
 <img class="cover-image" src="images/posterholder.png">


### PR DESCRIPTION
The ratings was showing too many numbers past the decimal in the watchlist and favorites view.  The ratings now properly displays as "9.4/10" instead of "9.433535/10".
