### PR TITLE
Fix: Subtitles and Theme CSS Cleanup

### DIFF
--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -15,7 +15,8 @@
     </section>
 
     <section id="user-interface">
-        <div class="content"><div class="title"><%= i18n.__("User Interface") %></div>
+        <div class="title"><%= i18n.__("User Interface") %></div>
+        <div class="content">
             <span>
                 <div class="dropdown subtitles-language">
                     <p><%= i18n.__("Default Language") %></p>
@@ -34,7 +35,7 @@
                 </div>
             </span>
 
-            <span class="advanced">
+            <span>
                 <div class="dropdown pct-theme">
                     <p><%= i18n.__("Theme") %></p>
                     <%
@@ -115,7 +116,8 @@
     </section>
 
     <section id="subtitles">
-        <div class="content"><div class="title"><%= i18n.__("Subtitles") %></div>
+        <div class="title"><%= i18n.__("Subtitles") %></div>
+        <div class="content">
             <span>
                 <div class="dropdown subtitles-language-default">
                     <p><%= i18n.__("Default Subtitle") %></p>
@@ -219,7 +221,7 @@
                 </div>
             </span>
 
-            <span class="advanced">
+            <span>
                 <div class="dropdown subtitles-size">
                     <p><%= i18n.__("Size") %></p>
                     <%
@@ -253,10 +255,10 @@
         </div>
     </section>
 
-    <section id="quality">
-        <div class="content"><div class="title"><%= i18n.__("Quality") %></div>
-	    <!--not working-->
-            <!--<span class="advanced">
+    <section id="quality" class="advanced">
+        <div class="title"><%= i18n.__("Quality") %></div>
+        <div class="content">
+            <span>
                 <div class="dropdown movies-quality">
                     <p><%= i18n.__("Only list movies in") %></p>
                     <select name="movies_quality">
@@ -266,7 +268,7 @@
                     </select>
                     <div class="dropdown-arrow"></div>
                 </div>
-            </span>-->
+            </span>
             <span>
                 <input class="settings-checkbox" name="moviesShowQuality" id="cb1" type="checkbox" <%=(Settings.moviesShowQuality? "checked='checked'":"")%>>
                 <label class="settings-label" for="cb1"><%= i18n.__("Show movie quality on list") %></label>
@@ -279,21 +281,22 @@
     </section>
 
     <section id="playback">
-        <div class="content"><div class="title"><%= i18n.__("Playback") %></div>
-            <span>
+        <div class="title"><%= i18n.__("Playback") %></div>
+        <div class="content">
+            <span class="advanced">
                 <input class="settings-checkbox" name="alwaysFullscreen" id="alwaysFullscreen" type="checkbox" <%=(Settings.alwaysFullscreen? "checked='checked'":"")%>>
                 <label class="settings-label" for="alwaysFullscreen"><%= i18n.__("Always start playing in fullscreen") %></label>
             </span>
-            <span class="advanced">
+            <span>
                 <input class="settings-checkbox" name="playNextEpisodeAuto" id="playNextEpisodeAuto" type="checkbox" <%=(Settings.playNextEpisodeAuto? "checked='checked'":"")%>>
                 <label class="settings-label" for="playNextEpisodeAuto"><%= i18n.__("Play next episode automatically") %></label>
             </span>
         </div>
     </section>
 
-
     <section id="features">
-        <div class="content"><div class="title"><%= i18n.__("Features") %></div>
+		<div class="title"><%= i18n.__("Features") %></div>
+        <div class="content">
             <span>
                 <input class="settings-checkbox" name="activateTorrentCollection" id="activateTorrentCollection" type="checkbox" <%=(Settings.activateTorrentCollection? "checked='checked'":"")%>>
                 <label class="settings-label" for="activateTorrentCollection"><%= i18n.__("Torrent Collection") %> - search on KAT, drop Magnet and .torrent</label>
@@ -302,24 +305,23 @@
                 <input class="settings-checkbox" name="activateFavorites" id="activateFavorites" type="checkbox" <%=(Settings.activateFavorites? "checked='checked'":"")%>>
                 <label class="settings-label" for="activateFavorites"><%= i18n.__("Favorites") %></label>
             </span>-->
-	    <span class="advanced">
+	    	<span>
                 <input class="settings-checkbox" name="activateWatchlist" id="activateWatchlist" type="checkbox" <%=(Settings.activateWatchlist? "checked='checked'":"")%>>
                 <label class="settings-label" for="activateWatchlist"><%= i18n.__("Watchlist") %></label>
             </span>
-            <!--<span class="advanced">
+            <!--<span>
                 <input class="settings-checkbox" name="activateVpn" id="activateVpn" type="checkbox" <%=(Settings.activateVpn? "checked='checked'":"")%>>
                 <label class="settings-label" for="activateVpn"><%= i18n.__("VPN") %></label>
             </span>
-            <span class="advanced">
+            <span>
                 <input class="settings-checkbox" name="activateRandomize" id="activateRandomize" type="checkbox" <%=(Settings.activateRandomize? "checked='checked'":"")%>>
                 <label class="settings-label" for="activateRandomize"><%= i18n.__("Randomize Button for Movies") %></label>
             </span>-->
         </div>
     </section>
-
-
     <section id="connection">
-        <div class="content"><div class="title"><%= i18n.__("Connection") %></div>
+		<div class="title"><%= i18n.__("Connection") %></div>
+        <div class="content">
 	    <span>
                 <p><%= i18n.__("Movie API Endpoint") %></p>
                     <input id="ytsAPI" type="text" size="50" name="ytsAPI" value="<%=Settings.ytsAPI[0].url%>">
@@ -327,22 +329,22 @@
                     &nbsp;&nbsp;<i class="reset-ytsAPI fa fa-undo tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__('Reset to Default Settings') %>"></i>
                     <% } %>
             </span>
-            <span class="advanced">
+            <span>
                 <p><%= i18n.__("TV Show API Endpoint") %></p>
                     <input id="tvAPI" type="text" size="50" name="tvAPI" value="<%=Settings.tvAPI[0].url%>">
                     <% if (Settings.tvAPI.length <= 1) { %>
                     &nbsp;&nbsp;<i class="reset-tvAPI fa fa-undo tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__('Reset to Default Settings') %>"></i>
                     <% } %>
             </span>
-            <span class="advanced">
+            <span>
                 <p><%= i18n.__("Connection Limit") %></p>
                 <input id="connectionLimit" type="text" size="20" name="connectionLimit" value="<%=Settings.connectionLimit%>"/>
             </span>
-            <span class="advanced">
+            <span>
                 <p><%= i18n.__("DHT Limit") %></p>
                 <input type="text" id="dhtLimit" size="20" name="dhtLimit" value="<%=Settings.dhtLimit%>"/>
             </span>
-            <span class="advanced">
+            <span>
                 <p><%= i18n.__("Port to stream on") %></p>
                 <input id="streamPort" type="text" size="20" name="streamPort" value="<%=Settings.streamPort%>"/>&nbsp;&nbsp;<em><%= i18n.__("0 = Random") %></em>
             </span>
@@ -360,7 +362,8 @@
     </section>
 
     <section id="cache" class="advanced">
-        <div class="content"><div class="title"><%= i18n.__("Cache Directory") %></div>
+		<div class="title"><%= i18n.__("Cache Directory") %></div>
+        <div class="content">
             <span>
                 <p><%= i18n.__("Cache Directory") %></p>
                 <input type="text" placeholder="<%= i18n.__("Cache Directory") %>" id="faketmpLocation" value="<%= Settings.tmpLocation %>" readonly="readonly" size="65" />
@@ -375,7 +378,8 @@
     </section>
 
     <section id="database" class="advanced">
-        <div class="content"><div class="title"><%= i18n.__("Database") %></div>
+		<div class="title"><%= i18n.__("Database") %></div>
+        <div class="content">
             <span>
                 <p><%= i18n.__("Database Directory") %></p>
                 <input type="text" placeholder="<%= i18n.__("Database Directory") %>" id="fakedatabaseLocation" value="<%= Settings.databaseLocation %>" readonly="readonly" size="65" />
@@ -395,9 +399,9 @@
         </div>
     </section>
 
-
-    <section id="trakt-tv" class="advanced">
-        <div class="content"><div class="title"><%= i18n.__("Trakt.tv") %></div>
+    <section id="trakt-tv">
+        <div class="title"><%= i18n.__("Trakt.tv") %></div>
+        <div class="content">
             <div class="trakt-options<%= App.Trakt.authenticated ? " authenticated" : "" %>">
                 <% if(App.Trakt.authenticated) { %>
                     <span>
@@ -434,8 +438,9 @@
         </div>
     </section>
 
-	<section id="tvshowtime" class="advanced">
-		<div class="content"><div class="title">TVShow Time</div>
+	<section id="tvshowtime">
+		<div class="title">TVShow Time</div>
+		<div class="content">
 			<div class="tvshowtime-options <%= App.TVShowTime.authenticated ? " authenticated" : "" %>">
 				<% if(App.TVShowTime.authenticated) { %>
                     <span>
@@ -456,7 +461,8 @@
 	</section>
 
     <section id="remote-control" class="advanced">
-        <div class="content"><div class="title"><%= i18n.__("Remote Control") %></div>
+        <div class="title"><%= i18n.__("Remote Control") %></div>
+        <div class="content">
             <span>
                 <p><%= i18n.__("Local IP Address") %></p>
                 <input type="text" id="settingsIpAddr" value="<%= Settings.ipAddress %>" readonly="readonly" size="20" />
@@ -490,10 +496,10 @@
         </div>
     </section>
 
-
-    <section id="miscellaneous">
-        <div class="content"><div class="title"><%= i18n.__("Miscellaneous") %></div>
-            <span class="advanced">
+    <section id="miscellaneous" class="advanced">
+        <div class="title"><%= i18n.__("Miscellaneous") %></div>
+        <div class="content">
+            <span>
                 <div class="dropdown tv_detail_jump_to">
                     <p><%= i18n.__("When Opening TV Series Detail Jump To") %></p>
                         <%
@@ -511,15 +517,15 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-            <span class="advanced">
+            <span>
                 <input class="settings-checkbox" name="automaticUpdating" id="cb5" type="checkbox" <%=(Settings.automaticUpdating? "checked='checked'":"")%>>
                 <label class="settings-label" for="cb5"><%= i18n.__("Activate automatic updating") %></label>
             </span>
-            <span class="advanced">
+            <span>
                 <input class="settings-checkbox" name="events" id="cb6" type="checkbox" <%=(Settings.events? "checked='checked'":"")%>>
                 <label class="settings-label" for="cb6"><%= i18n.__("Celebrate various events") %></label>
             </span>
-            <span class="advanced">
+            <span>
                 <input class="settings-checkbox" name="minimizeToTray" id="minimizeToTray" type="checkbox" <%=(Settings.minimizeToTray? "checked='checked'":"")%>>
                 <label class="settings-label" for="minimizeToTray"><%= i18n.__("Minimize to Tray") %></label>
             </span>

--- a/src/app/themes/Official_-_Black_&_Yellow_theme.css
+++ b/src/app/themes/Official_-_Black_&_Yellow_theme.css
@@ -277,6 +277,7 @@ ul.nav-hor > li {
   position: absolute;
   right: 3px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #player,
 .player {
@@ -730,6 +731,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-play-control:hover:before {
   text-shadow: none !important;
@@ -766,6 +768,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-volume-control {
   top: 17px;
@@ -914,6 +917,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-fullscreen-control:hover:before {
   text-shadow: none !important;
@@ -1073,6 +1077,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_smallersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1098,6 +1103,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_biggersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1117,6 +1123,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-hidden {
   display: none;
@@ -1288,8 +1295,7 @@ ul.nav-hor > li {
   font-weight: normal;
   font-style: normal;
   font-family: Arial, sans-serif;
-  -webkit-user-select: none;
-  user-select: none;
+  -ms-user-select: none;
   -webkit-user-select: none;
   user-select: none;
 }
@@ -1574,6 +1580,7 @@ body,
   top: 16%;
   opacity: 1;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .init-progressbar {
   position: relative;
@@ -1605,6 +1612,7 @@ body,
   height: calc(11%);
   max-height: 52px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
   -webkit-transition: -webkit-filter 0.5s;
   transition: -webkit-filter 0.5s;
 }
@@ -1652,6 +1660,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: 15%;
   -webkit-transition: color 0.5s, font-family 0.5s;
@@ -1688,6 +1697,7 @@ body,
   margin: 0 auto;
   -moz-animation: spin 0.5s infinite linear;
   -webkit-animation: spin 0.5s infinite linear;
+  animation: spin 0.5s infinite linear;
 }
 .loading-container .ball1 {
   background-color: rgba(0,0,0,0);
@@ -1707,6 +1717,7 @@ body,
   top: -50px;
   -moz-animation: spinoff 0.5s infinite linear;
   -webkit-animation: spinoff 0.5s infinite linear;
+  animation: spinoff 0.5s infinite linear;
 }
 #disclaimer-container .disclaimer {
   height: 100%;
@@ -1752,6 +1763,7 @@ body,
   left: 40px;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
 }
 #disclaimer-container .disclaimer .disclaimer-state .disclaimer-content {
@@ -2007,6 +2019,7 @@ body,
   cursor: pointer;
   background: url("../images/icons/topbar_sprite_win.png");
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-close {
   background-position: -40px 0px;
@@ -2023,10 +2036,12 @@ body,
 #header .btn-set.win32 .btn-os.os-close:hover {
   background-position: -100px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover {
   background-position: -80px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover.os-is-max:hover {
   background-position: -140px 0px;
@@ -2034,6 +2049,7 @@ body,
 #header .btn-set.win32 .btn-os.os-min:hover {
   background-position: -60px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.darwin .btn-os {
   background-image: none;
@@ -2289,6 +2305,7 @@ body,
   border-radius: 10em;
   -webkit-appearance: textfield;
   -webkit-box-sizing: content-box;
+  box-sizing: content-box;
   -webkit-transition: width 0.5s;
   transition: width 0.5s;
 }
@@ -2577,6 +2594,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-favorites.selected {
@@ -2595,6 +2613,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-watched:hover {
@@ -2702,6 +2721,7 @@ body,
   float: left;
   background-color: #070707;
   -webkit-transition: background-color 200ms linear;
+  transition: background-color 200ms linear;
 }
 .load-more > .loading-container {
   display: none;
@@ -2717,6 +2737,7 @@ body,
   left: 50%;
   margin: -25px;
   -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
 }
 .load-more > .loading-container .ball1 {
   margin: -15px;
@@ -2765,6 +2786,7 @@ body,
   padding-top: 65px;
   width: 100vw;
   -webkit-user-select: none;
+  -ms-user-select: none;
   user-select: none;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
@@ -2824,9 +2846,9 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-.movie-detail .content-box .meta-container {
+/*.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
-}
+}*/
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;
@@ -2846,7 +2868,8 @@ body,
   font-size: 12px;
   position: relative;
   font-family: 'Open Sans Bold';
-  text-stroke: 1px rgba(0,0,0,0.1);
+  -webkit-text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   float: left;
   -webkit-font-smoothing: antialiased;
   max-width: 35%;
@@ -3002,10 +3025,10 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-.movie-detail .content-box .bottom-container {
+/*.movie-detail .content-box .bottom-container {
   height: 70px;
   line-height: 35px;
-}
+}*/
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3155,7 +3178,7 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-.movie-detail .content-box .bottom-container .sub-dropdown {
+/*.movie-detail .content-box .bottom-container .sub-dropdown {
   position: relative;
   height: 26px;
   width: auto;
@@ -3186,30 +3209,30 @@ body,
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}
+}*/
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
 }
 .movie-detail .content-box .bottom-container .flag-container {
-  position: absolute;
+  position: relative;
   margin-right: 5.2%;
-  margin-top: 26px;
+  margin-top: 13px;
   z-index: 3;
   width: auto;
-  max-width: 330px;
+  max-width: 165px;
   max-height: 72px;
-  right: 0;
-  overflow-x: hidden;
-  overflow-y: hidden;
   display: none;
   height: auto;
   background: rgba(20,24,26,0.6);
+  float:left;
+  overflow:auto;
 }
+
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-.movie-detail .content-box .bottom-container .flag {
+/*.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3220,7 +3243,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}
+}*/
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3392,7 +3415,7 @@ body,
   left: 0;
   position: absolute;
 }
-.movie-detail .content-box .bottom-container .movie-quality-container {
+/*.movie-detail .content-box .bottom-container .movie-quality-container {
   margin-top: 10px;
   float: left;
   position: relative;
@@ -3400,7 +3423,7 @@ body,
   width: 95px;
   left: 3%;
   line-height: 1;
-}
+}*/
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -5735,8 +5758,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-.settings-container-contain .settings-container section .title {
-  padding-top: 26px;
+/*.settings-container-contain .settings-container section .title {
+  padding-bottom: 26px;
   color: #fc0;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5744,7 +5767,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid #333;
-}
+}*/
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;
@@ -6300,6 +6323,7 @@ body,
   right: 0;
   padding-top: 32px;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .loading .loading-background {
   position: absolute;
@@ -6330,6 +6354,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: calc(50% - 180px);
 }
@@ -6407,6 +6432,7 @@ body,
   background-clip: padding-box;
   background-color: #f3cc16;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
@@ -6421,6 +6447,7 @@ body,
 }
 .loading .state .cancel-button .cancel-button-text {
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   color: #fff;
   font-family: 'Open Sans Semibold', 'Open Sans', sans-serif;
@@ -6572,4 +6599,140 @@ body,
 #notification .notification p {
   font-weight: 100;
   line-height: 20px;
+}
+
+.about-container .content .icons_social a.github_icon {
+  background: url("../images/icons/icon-github.png") no-repeat center;
+  -webkit-background-size: contain;
+  background-size: contain;
+}
+.settings-container-contain .settings-container #connection .reset-ytsAPI {
+  font-size: 13px;
+  color: #8a8b8e;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+.settings-container-contain .settings-container #connection .reset-ytsAPI:hover {
+  cursor: pointer;
+  color: #2468cc;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar {
+  width: 5px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-track {
+  background-color: #30333c;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-thumb {
+  background-color: #83888c;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-thumb:hover {
+  background-color: #93989c;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-resizer,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-corner,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-button,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-track-piece {
+  display: none;
+}
+div.provider{cursor:pointer; float:left; margin-right:5px;}
+div.provider:hover{color:#fff;}
+.settings-container-contain .settings-container section .title {
+  padding-bottom: 26px;
+  color: #2d75df;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 17px;
+  width: 160px;
+  /*margin-right: 30px;*/
+  position: relative;
+  /*border-right: 1px solid #3a3b3e;*/
+}
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
+.movie-detail .content-box .meta-container .overview {
+  position: relative;
+  height: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  float: none;
+  color: #fff;
+  top: 25px;
+  padding-right: 2%;
+  font-family: 'Open Sans Semibold';
+  -webkit-font-smoothing: antialiased;
+  font-size: 13px;
+  line-height: 22px;
+  text-align: justify;
+  text-shadow: 1px rgba(0,0,0,0.1);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  overflow-x: hidden;
+  overflow-y: overlay;
+  -webkit-overflow-scrolling: touch;
+}
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
+  line-height: 35px;
+}
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
+  position: relative;
+  height: 26px;
+  width: auto;
+  float: left;
+  /*margin-right: 2%;*/
+  color: #fff;
+  font-family: 'Open Sans Semibold';
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 17px;
+  cursor: pointer;
+  padding: 5px;
+  padding-right: 13px;
+  padding-top: 10px;
+}
+.movie-detail .content-box .bottom-container .sub-dropdown.open {
+  /*background-color: rgba(36,104,204,0.6);
+  -webkit-border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
+}
+.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  top: 15px;
+  position: absolute;
+  float: left;
+  right: 5px;
+  border-top: 5px solid #c4c6c8;
+  border-bottom: none;
+}
+.movie-detail .content-box .bottom-container .flag {
+  margin: 3px;
+  background-image: url("../images/flags/none.png");
+  -webkit-background-size: 24px 24px;
+  background-size: 24px 24px;
+  background-position: center;
+  position: relative;
+  float: right;
+  cursor: pointer;
+  width: 24px;
+  height: 22px;
+}
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
+  float: left;
+  position: relative;
+  height: 15px;
+  width: 125px;
+  left: 15px;
+  line-height: 1;
 }

--- a/src/app/themes/Official_-_Black_&_Yellow_theme.css
+++ b/src/app/themes/Official_-_Black_&_Yellow_theme.css
@@ -1602,7 +1602,7 @@ body,
 }
 .icon-begin {
   display: block;
-  margin: -7px auto;
+  margin: 0px auto;
   height: calc(58%);
   max-height: 256px;
 }
@@ -2085,7 +2085,7 @@ body,
   height: 28px;
   position: absolute;
   top: -6px;
-  left: calc(50% + 52px);
+  left: calc(50% + 64px);
   display: none;
 }
 .events.img-newyear {
@@ -2846,9 +2846,14 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-/*.movie-detail .content-box .meta-container {
+/*
+.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
 }*/
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;
@@ -2984,7 +2989,7 @@ body,
 }
 .movie-detail .content-box .meta-container .overview {
   position: relative;
-  height: 55%;
+  height: 70%;
   overflow: hidden;
   text-overflow: ellipsis;
   float: none;
@@ -3025,10 +3030,11 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-/*.movie-detail .content-box .bottom-container {
-  height: 70px;
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
   line-height: 35px;
-}*/
+}
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3178,12 +3184,12 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-/*.movie-detail .content-box .bottom-container .sub-dropdown {
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
   position: relative;
   height: 26px;
   width: auto;
-  float: right;
-  margin-right: 2%;
+  float: left;
+  /*margin-right: 2%;*/
   color: #fff;
   font-family: 'Open Sans Semibold';
   -webkit-font-smoothing: antialiased;
@@ -3192,24 +3198,25 @@ body,
   cursor: pointer;
   padding: 5px;
   padding-right: 13px;
+  padding-top: 10px;
 }
 .movie-detail .content-box .bottom-container .sub-dropdown.open {
-  background-color: rgba(255,204,0,0.6);
+  /*background-color: rgba(255,204,0,0.6);
   -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
 }
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
   width: 0;
   height: 0;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  top: 10px;
+  top: 15px;
   position: absolute;
   float: left;
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}*/
+}
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
@@ -3232,7 +3239,7 @@ body,
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-/*.movie-detail .content-box .bottom-container .flag {
+.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3243,7 +3250,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}*/
+}
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3415,15 +3422,15 @@ body,
   left: 0;
   position: absolute;
 }
-/*.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 10px;
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
   float: left;
   position: relative;
   height: 15px;
-  width: 95px;
-  left: 3%;
+  width: 125px;
+  left: 15px;
   line-height: 1;
-}*/
+}
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -5758,8 +5765,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-/*.settings-container-contain .settings-container section .title {
-  padding-bottom: 26px;
+.settings-container-contain .settings-container section .title {
+  padding-top: 26px;
   color: #fc0;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5767,7 +5774,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid #333;
-}*/
+}
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;
@@ -6651,88 +6658,4 @@ div.provider:hover{color:#fff;}
   /*margin-right: 30px;*/
   position: relative;
   /*border-right: 1px solid #3a3b3e;*/
-}
-.movie-detail .content-box .meta-container {
-  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
-  height: calc(100% - 110px);
-}
-.movie-detail .content-box .meta-container .overview {
-  position: relative;
-  height: 70%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  float: none;
-  color: #fff;
-  top: 25px;
-  padding-right: 2%;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 13px;
-  line-height: 22px;
-  text-align: justify;
-  text-shadow: 1px rgba(0,0,0,0.1);
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  overflow-x: hidden;
-  overflow-y: overlay;
-  -webkit-overflow-scrolling: touch;
-}
-.movie-detail .content-box .bottom-container {
-  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
-  height: 110px;
-  line-height: 35px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
-  position: relative;
-  height: 26px;
-  width: auto;
-  float: left;
-  /*margin-right: 2%;*/
-  color: #fff;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 12px;
-  line-height: 17px;
-  cursor: pointer;
-  padding: 5px;
-  padding-right: 13px;
-  padding-top: 10px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown.open {
-  /*background-color: rgba(36,104,204,0.6);
-  -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;*/
-}
-.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
-  width: 0;
-  height: 0;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  top: 15px;
-  position: absolute;
-  float: left;
-  right: 5px;
-  border-top: 5px solid #c4c6c8;
-  border-bottom: none;
-}
-.movie-detail .content-box .bottom-container .flag {
-  margin: 3px;
-  background-image: url("../images/flags/none.png");
-  -webkit-background-size: 24px 24px;
-  background-size: 24px 24px;
-  background-position: center;
-  position: relative;
-  float: right;
-  cursor: pointer;
-  width: 24px;
-  height: 22px;
-}
-.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 13px;
-  float: left;
-  position: relative;
-  height: 15px;
-  width: 125px;
-  left: 15px;
-  line-height: 1;
 }

--- a/src/app/themes/Official_-_Dark_theme.css
+++ b/src/app/themes/Official_-_Dark_theme.css
@@ -2846,9 +2846,14 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-/*.movie-detail .content-box .meta-container {
+/*
+.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
 }*/
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;
@@ -2984,7 +2989,7 @@ body,
 }
 .movie-detail .content-box .meta-container .overview {
   position: relative;
-  height: 55%;
+  height: 70%;
   overflow: hidden;
   text-overflow: ellipsis;
   float: none;
@@ -3025,10 +3030,11 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-/*.movie-detail .content-box .bottom-container {
-  height: 70px;
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
   line-height: 35px;
-}*/
+}
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3178,12 +3184,12 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-/*.movie-detail .content-box .bottom-container .sub-dropdown {
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
   position: relative;
   height: 26px;
   width: auto;
-  float: right;
-  margin-right: 2%;
+  float: left;
+  /*margin-right: 2%;*/
   color: #fff;
   font-family: 'Open Sans Semibold';
   -webkit-font-smoothing: antialiased;
@@ -3192,24 +3198,25 @@ body,
   cursor: pointer;
   padding: 5px;
   padding-right: 13px;
+  padding-top: 10px;
 }
 .movie-detail .content-box .bottom-container .sub-dropdown.open {
-  background-color: rgba(36,104,204,0.6);
+  /*background-color: rgba(36,104,204,0.6);
   -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
 }
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
   width: 0;
   height: 0;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  top: 10px;
+  top: 15px;
   position: absolute;
   float: left;
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}*/
+}
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
@@ -3231,7 +3238,7 @@ body,
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-/*.movie-detail .content-box .bottom-container .flag {
+.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3242,7 +3249,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}*/
+}
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3414,15 +3421,15 @@ body,
   left: 0;
   position: absolute;
 }
-/*.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 10px;
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
   float: left;
   position: relative;
   height: 15px;
-  width: 95px;
-  left: 3%;
+  width: 125px;
+  left: 15px;
   line-height: 1;
-}*/
+}
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -3517,6 +3524,8 @@ body,
   top: -1px;
   width: 10px;
 }
+
+
 #movie-error .button {
   position: absolute;
   cursor: pointer;
@@ -6650,88 +6659,4 @@ div.provider:hover{color:#fff;}
   /*margin-right: 30px;*/
   position: relative;
   /*border-right: 1px solid #3a3b3e;*/
-}
-.movie-detail .content-box .meta-container {
-  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
-  height: calc(100% - 110px);
-}
-.movie-detail .content-box .meta-container .overview {
-  position: relative;
-  height: 70%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  float: none;
-  color: #fff;
-  top: 25px;
-  padding-right: 2%;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 13px;
-  line-height: 22px;
-  text-align: justify;
-  text-shadow: 1px rgba(0,0,0,0.1);
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  overflow-x: hidden;
-  overflow-y: overlay;
-  -webkit-overflow-scrolling: touch;
-}
-.movie-detail .content-box .bottom-container {
-  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
-  height: 110px;
-  line-height: 35px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
-  position: relative;
-  height: 26px;
-  width: auto;
-  float: left;
-  /*margin-right: 2%;*/
-  color: #fff;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 12px;
-  line-height: 17px;
-  cursor: pointer;
-  padding: 5px;
-  padding-right: 13px;
-  padding-top: 10px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown.open {
-  /*background-color: rgba(36,104,204,0.6);
-  -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;*/
-}
-.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
-  width: 0;
-  height: 0;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  top: 15px;
-  position: absolute;
-  float: left;
-  right: 5px;
-  border-top: 5px solid #c4c6c8;
-  border-bottom: none;
-}
-.movie-detail .content-box .bottom-container .flag {
-  margin: 3px;
-  background-image: url("../images/flags/none.png");
-  -webkit-background-size: 24px 24px;
-  background-size: 24px 24px;
-  background-position: center;
-  position: relative;
-  float: right;
-  cursor: pointer;
-  width: 24px;
-  height: 22px;
-}
-.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 13px;
-  float: left;
-  position: relative;
-  height: 15px;
-  width: 125px;
-  left: 15px;
-  line-height: 1;
 }

--- a/src/app/themes/Official_-_Dark_theme.css
+++ b/src/app/themes/Official_-_Dark_theme.css
@@ -1602,7 +1602,7 @@ body,
 }
 .icon-begin {
   display: block;
-  margin: -7px auto;
+  margin: 0px auto;
   height: calc(58%);
   max-height: 256px;
 }
@@ -2085,7 +2085,7 @@ body,
   height: 28px;
   position: absolute;
   top: -6px;
-  left: calc(50% + 52px);
+  left: calc(50% + 64px);
   display: none;
 }
 .events.img-newyear {
@@ -5766,8 +5766,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-/*.settings-container-contain .settings-container section .title {
-  padding-bottom: 26px;
+.settings-container-contain .settings-container section .title {
+  padding-top: 26px;
   color: #2d75df;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5775,7 +5775,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid #3a3b3e;
-}*/
+}
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;

--- a/src/app/themes/Official_-_Dark_theme.css
+++ b/src/app/themes/Official_-_Dark_theme.css
@@ -277,6 +277,7 @@ ul.nav-hor > li {
   position: absolute;
   right: 3px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #player,
 .player {
@@ -730,6 +731,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-play-control:hover:before {
   text-shadow: none !important;
@@ -766,6 +768,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-volume-control {
   top: 17px;
@@ -914,6 +917,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-fullscreen-control:hover:before {
   text-shadow: none !important;
@@ -1073,6 +1077,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_smallersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1098,6 +1103,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_biggersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1117,6 +1123,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-hidden {
   display: none;
@@ -1288,8 +1295,7 @@ ul.nav-hor > li {
   font-weight: normal;
   font-style: normal;
   font-family: Arial, sans-serif;
-  -webkit-user-select: none;
-  user-select: none;
+  -ms-user-select: none;
   -webkit-user-select: none;
   user-select: none;
 }
@@ -1574,6 +1580,7 @@ body,
   top: 16%;
   opacity: 1;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .init-progressbar {
   position: relative;
@@ -1605,6 +1612,7 @@ body,
   height: calc(11%);
   max-height: 52px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
   -webkit-transition: -webkit-filter 0.5s;
   transition: -webkit-filter 0.5s;
 }
@@ -1652,6 +1660,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: 15%;
   -webkit-transition: color 0.5s, font-family 0.5s;
@@ -1688,6 +1697,7 @@ body,
   margin: 0 auto;
   -moz-animation: spin 0.5s infinite linear;
   -webkit-animation: spin 0.5s infinite linear;
+  animation: spin 0.5s infinite linear;
 }
 .loading-container .ball1 {
   background-color: rgba(0,0,0,0);
@@ -1707,6 +1717,7 @@ body,
   top: -50px;
   -moz-animation: spinoff 0.5s infinite linear;
   -webkit-animation: spinoff 0.5s infinite linear;
+  animation: spinoff 0.5s infinite linear;
 }
 #disclaimer-container .disclaimer {
   height: 100%;
@@ -1752,6 +1763,7 @@ body,
   left: 40px;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
 }
 #disclaimer-container .disclaimer .disclaimer-state .disclaimer-content {
@@ -2007,6 +2019,7 @@ body,
   cursor: pointer;
   background: url("../images/icons/topbar_sprite_win.png");
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-close {
   background-position: -40px 0px;
@@ -2023,10 +2036,12 @@ body,
 #header .btn-set.win32 .btn-os.os-close:hover {
   background-position: -100px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover {
   background-position: -80px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover.os-is-max:hover {
   background-position: -140px 0px;
@@ -2034,6 +2049,7 @@ body,
 #header .btn-set.win32 .btn-os.os-min:hover {
   background-position: -60px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.darwin .btn-os {
   background-image: none;
@@ -2289,6 +2305,7 @@ body,
   border-radius: 10em;
   -webkit-appearance: textfield;
   -webkit-box-sizing: content-box;
+  box-sizing: content-box;
   -webkit-transition: width 0.5s;
   transition: width 0.5s;
 }
@@ -2577,6 +2594,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-favorites.selected {
@@ -2595,6 +2613,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-watched:hover {
@@ -2702,6 +2721,7 @@ body,
   float: left;
   background-color: #17181b;
   -webkit-transition: background-color 200ms linear;
+  transition: background-color 200ms linear;
 }
 .load-more > .loading-container {
   display: none;
@@ -2717,6 +2737,7 @@ body,
   left: 50%;
   margin: -25px;
   -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
 }
 .load-more > .loading-container .ball1 {
   margin: -15px;
@@ -2765,6 +2786,7 @@ body,
   padding-top: 65px;
   width: 100vw;
   -webkit-user-select: none;
+  -ms-user-select: none;
   user-select: none;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
@@ -2846,7 +2868,8 @@ body,
   font-size: 12px;
   position: relative;
   font-family: 'Open Sans Bold';
-  text-stroke: 1px rgba(0,0,0,0.1);
+  -webkit-text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   float: left;
   -webkit-font-smoothing: antialiased;
   max-width: 35%;
@@ -2959,7 +2982,7 @@ body,
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
-/*.movie-detail .content-box .meta-container .overview {
+.movie-detail .content-box .meta-container .overview {
   position: relative;
   height: 55%;
   overflow: hidden;
@@ -2973,13 +2996,13 @@ body,
   font-size: 13px;
   line-height: 22px;
   text-align: justify;
-  text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   overflow-x: hidden;
   overflow-y: overlay;
   -webkit-overflow-scrolling: touch;
-}*/
+}
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar {
   width: 5px;
 }
@@ -3191,21 +3214,20 @@ body,
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
 }
-/*.movie-detail .content-box .bottom-container .flag-container {
-  position: absolute;
+.movie-detail .content-box .bottom-container .flag-container {
+  position: relative;
   margin-right: 5.2%;
-  margin-top: 26px;
+  margin-top: 13px;
   z-index: 3;
   width: auto;
-  max-width: 330px;
+  max-width: 165px;
   max-height: 72px;
-  right: 0;
-  overflow-x: hidden;
-  overflow-y: hidden;
   display: none;
   height: auto;
   background: rgba(20,24,26,0.6);
-}*/
+  float:left;
+  overflow:auto;
+}
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
@@ -6300,6 +6322,7 @@ body,
   right: 0;
   padding-top: 32px;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .loading .loading-background {
   position: absolute;
@@ -6330,6 +6353,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: calc(50% - 180px);
 }
@@ -6407,6 +6431,7 @@ body,
   background-clip: padding-box;
   background-color: #1f375f;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
@@ -6421,6 +6446,7 @@ body,
 }
 .loading .state .cancel-button .cancel-button-text {
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   color: #fff;
   font-family: 'Open Sans Semibold', 'Open Sans', sans-serif;
@@ -6574,19 +6600,6 @@ body,
   line-height: 20px;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 .about-container .content .icons_social a.github_icon {
   background: url("../images/icons/icon-github.png") no-repeat center;
   -webkit-background-size: contain;
@@ -6644,7 +6657,7 @@ div.provider:hover{color:#fff;}
 }
 .movie-detail .content-box .meta-container .overview {
   position: relative;
-height: 70%;
+  height: 70%;
   overflow: hidden;
   text-overflow: ellipsis;
   float: none;
@@ -6656,7 +6669,7 @@ height: 70%;
   font-size: 13px;
   line-height: 22px;
   text-align: justify;
-  text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   overflow-x: hidden;
@@ -6665,7 +6678,7 @@ height: 70%;
 }
 .movie-detail .content-box .bottom-container {
   /*be carefull - dependent on .movie-detail .content-box .meta-container*/
-height: 110px;
+  height: 110px;
   line-height: 35px;
 }
 .movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
@@ -6682,7 +6695,7 @@ height: 110px;
   cursor: pointer;
   padding: 5px;
   padding-right: 13px;
-padding-top: 10px;
+  padding-top: 10px;
 }
 .movie-detail .content-box .bottom-container .sub-dropdown.open {
   /*background-color: rgba(36,104,204,0.6);
@@ -6694,29 +6707,12 @@ padding-top: 10px;
   height: 0;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-top: 15px;
+  top: 15px;
   position: absolute;
   float: left;
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}
-.movie-detail .content-box .bottom-container .flag-container {/*subtitles*/
-  position: relative;
-  /*margin-right: 5.2%;*/
-  margin-top: 13px;
-  z-index: 3;
-  width: auto;
-max-width: 165px;
-  max-height: 72px;
-  /*right: 0;
-  overflow-x: hidden;
-  overflow-y: hidden;*/
-  display: none;
-  height: auto;
-  background: rgba(20,24,26,0.6);
-float:left;
-overflow:auto;
 }
 .movie-detail .content-box .bottom-container .flag {
   margin: 3px;
@@ -6731,11 +6727,11 @@ overflow:auto;
   height: 22px;
 }
 .movie-detail .content-box .bottom-container .movie-quality-container {
-margin-top: 13px;
+  margin-top: 13px;
   float: left;
   position: relative;
   height: 15px;
   width: 125px;
-left: 15px;
+  left: 15px;
   line-height: 1;
 }

--- a/src/app/themes/Official_-_Dark_theme.css
+++ b/src/app/themes/Official_-_Dark_theme.css
@@ -3001,7 +3001,7 @@ body,
   font-size: 13px;
   line-height: 22px;
   text-align: justify;
-  text-shadow: 1px rgba(0,0,0,0.1);
+  text-stroke: 1px rgba(0,0,0,0.1);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   overflow-x: hidden;

--- a/src/app/themes/Official_-_FlaX_theme.css
+++ b/src/app/themes/Official_-_FlaX_theme.css
@@ -2085,7 +2085,7 @@ body,
   height: 28px;
   position: absolute;
   top: -6px;
-  left: calc(50% + 52px);
+  left: calc(50% + 64px);
   display: none;
 }
 .events.img-newyear {
@@ -2846,9 +2846,14 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-/*.movie-detail .content-box .meta-container {
+/*
+.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
 }*/
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;
@@ -2996,7 +3001,7 @@ body,
   font-size: 13px;
   line-height: 22px;
   text-align: justify;
-  text-shadow: 1px rgba(0,0,0,0.1);
+  text-stroke: 1px rgba(0,0,0,0.1);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   overflow-x: hidden;
@@ -3025,10 +3030,11 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-/*.movie-detail .content-box .bottom-container {
-  height: 70px;
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
   line-height: 35px;
-}*/
+}
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3178,12 +3184,12 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-/*.movie-detail .content-box .bottom-container .sub-dropdown {
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
   position: relative;
   height: 26px;
   width: auto;
-  float: right;
-  margin-right: 2%;
+  float: left;
+  /*margin-right: 2%;*/
   color: #fff;
   font-family: 'Open Sans Semibold';
   -webkit-font-smoothing: antialiased;
@@ -3192,24 +3198,25 @@ body,
   cursor: pointer;
   padding: 5px;
   padding-right: 13px;
+  padding-top: 10px;
 }
 .movie-detail .content-box .bottom-container .sub-dropdown.open {
-  background-color: rgba(217,57,75,0.6);
+  /*background-color: rgba(217,57,75,0.6);
   -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
 }
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
   width: 0;
   height: 0;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  top: 10px;
+  top: 15px;
   position: absolute;
   float: left;
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}*/
+}
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
@@ -3231,7 +3238,7 @@ body,
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-/*.movie-detail .content-box .bottom-container .flag {
+.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3242,7 +3249,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}*/
+}
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3414,15 +3421,15 @@ body,
   left: 0;
   position: absolute;
 }
-/*.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 10px;
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
   float: left;
   position: relative;
   height: 15px;
-  width: 95px;
-  left: 3%;
+  width: 125px;
+  left: 15px;
   line-height: 1;
-}*/
+}
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -5757,8 +5764,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-/*.settings-container-contain .settings-container section .title {
-  padding-bottom: 26px;
+.settings-container-contain .settings-container section .title {
+  padding-top: 26px;
   color: #f5f7fa;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5766,7 +5773,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid rgba(255,255,255,0.1);
-}*/
+}
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;
@@ -6650,97 +6657,3 @@ div.provider:hover{color:#fff;}
   position: relative;
   /*border-right: 1px solid #3a3b3e;*/
 }
-.movie-detail .content-box .meta-container {
-  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
-  height: calc(100% - 110px);
-}
-.movie-detail .content-box .meta-container .overview {
-  position: relative;
-  height: 70%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  float: none;
-  color: #fff;
-  top: 25px;
-  padding-right: 2%;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 13px;
-  line-height: 22px;
-  text-align: justify;
-  text-shadow: 1px rgba(0,0,0,0.1);
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  overflow-x: hidden;
-  overflow-y: overlay;
-  -webkit-overflow-scrolling: touch;
-}
-.movie-detail .content-box .bottom-container {
-  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
-  height: 110px;
-  line-height: 35px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
-  position: relative;
-  height: 26px;
-  width: auto;
-  float: left;
-  /*margin-right: 2%;*/
-  color: #fff;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 12px;
-  line-height: 17px;
-  cursor: pointer;
-  padding: 5px;
-  padding-right: 13px;
-  padding-top: 10px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown.open {
-  /*background-color: rgba(36,104,204,0.6);
-  -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;*/
-}
-.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
-  width: 0;
-  height: 0;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  top: 15px;
-  position: absolute;
-  float: left;
-  right: 5px;
-  border-top: 5px solid #c4c6c8;
-  border-bottom: none;
-}
-.movie-detail .content-box .bottom-container .flag {
-  margin: 3px;
-  background-image: url("../images/flags/none.png");
-  -webkit-background-size: 24px 24px;
-  background-size: 24px 24px;
-  background-position: center;
-  position: relative;
-  float: right;
-  cursor: pointer;
-  width: 24px;
-  height: 22px;
-}
-.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 13px;
-  float: left;
-  position: relative;
-  height: 15px;
-  width: 125px;
-  left: 15px;
-  line-height: 1;
-}
-/*
-.init-progressbar > div,
-.loading .state .loading-progressbar > div {
-  background-color: #de5362;
-}
-.show-quality-container .toggle,
-.movie-detail .content-box .bottom-container .movie-quality-container .switch .toggle {
-  background: #de5362;
-}
-*/

--- a/src/app/themes/Official_-_FlaX_theme.css
+++ b/src/app/themes/Official_-_FlaX_theme.css
@@ -277,6 +277,7 @@ ul.nav-hor > li {
   position: absolute;
   right: 3px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #player,
 .player {
@@ -730,6 +731,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-play-control:hover:before {
   text-shadow: none !important;
@@ -766,6 +768,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-volume-control {
   top: 17px;
@@ -914,6 +917,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-fullscreen-control:hover:before {
   text-shadow: none !important;
@@ -1073,6 +1077,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_smallersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1098,6 +1103,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_biggersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1117,6 +1123,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-hidden {
   display: none;
@@ -1288,8 +1295,7 @@ ul.nav-hor > li {
   font-weight: normal;
   font-style: normal;
   font-family: Arial, sans-serif;
-  -webkit-user-select: none;
-  user-select: none;
+  -ms-user-select: none;
   -webkit-user-select: none;
   user-select: none;
 }
@@ -1574,6 +1580,7 @@ body,
   top: 16%;
   opacity: 1;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .init-progressbar {
   position: relative;
@@ -1605,6 +1612,7 @@ body,
   height: calc(11%);
   max-height: 52px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
   -webkit-transition: -webkit-filter 0.5s;
   transition: -webkit-filter 0.5s;
 }
@@ -1652,6 +1660,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: 15%;
   -webkit-transition: color 0.5s, font-family 0.5s;
@@ -1688,6 +1697,7 @@ body,
   margin: 0 auto;
   -moz-animation: spin 0.5s infinite linear;
   -webkit-animation: spin 0.5s infinite linear;
+  animation: spin 0.5s infinite linear;
 }
 .loading-container .ball1 {
   background-color: rgba(0,0,0,0);
@@ -1707,6 +1717,7 @@ body,
   top: -50px;
   -moz-animation: spinoff 0.5s infinite linear;
   -webkit-animation: spinoff 0.5s infinite linear;
+  animation: spinoff 0.5s infinite linear;
 }
 #disclaimer-container .disclaimer {
   height: 100%;
@@ -1752,6 +1763,7 @@ body,
   left: 40px;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
 }
 #disclaimer-container .disclaimer .disclaimer-state .disclaimer-content {
@@ -2007,6 +2019,7 @@ body,
   cursor: pointer;
   background: url("../images/icons/topbar_sprite_win.png");
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-close {
   background-position: -40px 0px;
@@ -2023,10 +2036,12 @@ body,
 #header .btn-set.win32 .btn-os.os-close:hover {
   background-position: -100px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover {
   background-position: -80px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover.os-is-max:hover {
   background-position: -140px 0px;
@@ -2034,6 +2049,7 @@ body,
 #header .btn-set.win32 .btn-os.os-min:hover {
   background-position: -60px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.darwin .btn-os {
   background-image: none;
@@ -2289,6 +2305,7 @@ body,
   border-radius: 10em;
   -webkit-appearance: textfield;
   -webkit-box-sizing: content-box;
+  box-sizing: content-box;
   -webkit-transition: width 0.5s;
   transition: width 0.5s;
 }
@@ -2577,6 +2594,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-favorites.selected {
@@ -2595,6 +2613,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-watched:hover {
@@ -2702,6 +2721,7 @@ body,
   float: left;
   background-color: #191d22;
   -webkit-transition: background-color 200ms linear;
+  transition: background-color 200ms linear;
 }
 .load-more > .loading-container {
   display: none;
@@ -2717,6 +2737,7 @@ body,
   left: 50%;
   margin: -25px;
   -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
 }
 .load-more > .loading-container .ball1 {
   margin: -15px;
@@ -2765,6 +2786,7 @@ body,
   padding-top: 65px;
   width: 100vw;
   -webkit-user-select: none;
+  -ms-user-select: none;
   user-select: none;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
@@ -2824,9 +2846,9 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-.movie-detail .content-box .meta-container {
+/*.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
-}
+}*/
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;
@@ -2846,7 +2868,8 @@ body,
   font-size: 12px;
   position: relative;
   font-family: 'Open Sans Bold';
-  text-stroke: 1px rgba(0,0,0,0.1);
+  -webkit-text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   float: left;
   -webkit-font-smoothing: antialiased;
   max-width: 35%;
@@ -2973,7 +2996,7 @@ body,
   font-size: 13px;
   line-height: 22px;
   text-align: justify;
-  text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   overflow-x: hidden;
@@ -3002,10 +3025,10 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-.movie-detail .content-box .bottom-container {
+/*.movie-detail .content-box .bottom-container {
   height: 70px;
   line-height: 35px;
-}
+}*/
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3155,7 +3178,7 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-.movie-detail .content-box .bottom-container .sub-dropdown {
+/*.movie-detail .content-box .bottom-container .sub-dropdown {
   position: relative;
   height: 26px;
   width: auto;
@@ -3186,30 +3209,29 @@ body,
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}
+}*/
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
 }
 .movie-detail .content-box .bottom-container .flag-container {
-  position: absolute;
+  position: relative;
   margin-right: 5.2%;
-  margin-top: 26px;
+  margin-top: 13px;
   z-index: 3;
   width: auto;
-  max-width: 330px;
+  max-width: 165px;
   max-height: 72px;
-  right: 0;
-  overflow-x: hidden;
-  overflow-y: hidden;
   display: none;
   height: auto;
   background: rgba(20,24,26,0.6);
+  float:left;
+  overflow:auto;
 }
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-.movie-detail .content-box .bottom-container .flag {
+/*.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3220,7 +3242,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}
+}*/
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3392,7 +3414,7 @@ body,
   left: 0;
   position: absolute;
 }
-.movie-detail .content-box .bottom-container .movie-quality-container {
+/*.movie-detail .content-box .bottom-container .movie-quality-container {
   margin-top: 10px;
   float: left;
   position: relative;
@@ -3400,7 +3422,7 @@ body,
   width: 95px;
   left: 3%;
   line-height: 1;
-}
+}*/
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -5735,8 +5757,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-.settings-container-contain .settings-container section .title {
-  padding-top: 26px;
+/*.settings-container-contain .settings-container section .title {
+  padding-bottom: 26px;
   color: #f5f7fa;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5744,7 +5766,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid rgba(255,255,255,0.1);
-}
+}*/
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;
@@ -6300,6 +6322,7 @@ body,
   right: 0;
   padding-top: 32px;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .loading .loading-background {
   position: absolute;
@@ -6330,6 +6353,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: calc(50% - 180px);
 }
@@ -6407,6 +6431,7 @@ body,
   background-clip: padding-box;
   background-color: #de5362;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
@@ -6421,6 +6446,7 @@ body,
 }
 .loading .state .cancel-button .cancel-button-text {
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   color: #fff;
   font-family: 'Open Sans Semibold', 'Open Sans', sans-serif;
@@ -6573,6 +6599,142 @@ body,
   font-weight: 100;
   line-height: 20px;
 }
+.about-container .content .icons_social a.github_icon {
+  background: url("../images/icons/icon-github.png") no-repeat center;
+  -webkit-background-size: contain;
+  background-size: contain;
+}
+.settings-container-contain .settings-container #connection .reset-ytsAPI {
+  font-size: 13px;
+  color: #8a8b8e;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+.settings-container-contain .settings-container #connection .reset-ytsAPI:hover {
+  cursor: pointer;
+  color: #2468cc;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar {
+  width: 5px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-track {
+  background-color: #30333c;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-thumb {
+  background-color: #83888c;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-thumb:hover {
+  background-color: #93989c;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-resizer,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-corner,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-button,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-track-piece {
+  display: none;
+}
+div.provider{cursor:pointer; float:left; margin-right:5px;}
+div.provider:hover{color:#fff;}
+.settings-container-contain .settings-container section .title {
+  padding-bottom: 26px;
+  color: #2d75df;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 17px;
+  width: 160px;
+  /*margin-right: 30px;*/
+  position: relative;
+  /*border-right: 1px solid #3a3b3e;*/
+}
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
+.movie-detail .content-box .meta-container .overview {
+  position: relative;
+  height: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  float: none;
+  color: #fff;
+  top: 25px;
+  padding-right: 2%;
+  font-family: 'Open Sans Semibold';
+  -webkit-font-smoothing: antialiased;
+  font-size: 13px;
+  line-height: 22px;
+  text-align: justify;
+  text-shadow: 1px rgba(0,0,0,0.1);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  overflow-x: hidden;
+  overflow-y: overlay;
+  -webkit-overflow-scrolling: touch;
+}
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
+  line-height: 35px;
+}
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
+  position: relative;
+  height: 26px;
+  width: auto;
+  float: left;
+  /*margin-right: 2%;*/
+  color: #fff;
+  font-family: 'Open Sans Semibold';
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 17px;
+  cursor: pointer;
+  padding: 5px;
+  padding-right: 13px;
+  padding-top: 10px;
+}
+.movie-detail .content-box .bottom-container .sub-dropdown.open {
+  /*background-color: rgba(36,104,204,0.6);
+  -webkit-border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
+}
+.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  top: 15px;
+  position: absolute;
+  float: left;
+  right: 5px;
+  border-top: 5px solid #c4c6c8;
+  border-bottom: none;
+}
+.movie-detail .content-box .bottom-container .flag {
+  margin: 3px;
+  background-image: url("../images/flags/none.png");
+  -webkit-background-size: 24px 24px;
+  background-size: 24px 24px;
+  background-position: center;
+  position: relative;
+  float: right;
+  cursor: pointer;
+  width: 24px;
+  height: 22px;
+}
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
+  float: left;
+  position: relative;
+  height: 15px;
+  width: 125px;
+  left: 15px;
+  line-height: 1;
+}
+/*
 .init-progressbar > div,
 .loading .state .loading-progressbar > div {
   background-color: #de5362;
@@ -6581,3 +6743,4 @@ body,
 .movie-detail .content-box .bottom-container .movie-quality-container .switch .toggle {
   background: #de5362;
 }
+*/

--- a/src/app/themes/Official_-_Flat_UI_theme.css
+++ b/src/app/themes/Official_-_Flat_UI_theme.css
@@ -1602,7 +1602,7 @@ body,
 }
 .icon-begin {
   display: block;
-  margin: -7px auto;
+  margin: 0px auto;
   height: calc(58%);
   max-height: 256px;
 }
@@ -2085,7 +2085,7 @@ body,
   height: 28px;
   position: absolute;
   top: -6px;
-  left: calc(50% + 52px);
+  left: calc(50% + 64px);
   display: none;
 }
 .events.img-newyear {
@@ -2846,9 +2846,14 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-/*.movie-detail .content-box .meta-container {
+/*
+.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
 }*/
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;
@@ -2984,7 +2989,7 @@ body,
 }
 .movie-detail .content-box .meta-container .overview {
   position: relative;
-  height: 55%;
+  height: 70%;
   overflow: hidden;
   text-overflow: ellipsis;
   float: none;
@@ -3025,10 +3030,11 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-/*.movie-detail .content-box .bottom-container {
-  height: 70px;
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
   line-height: 35px;
-}*/
+}
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3178,12 +3184,12 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-/*.movie-detail .content-box .bottom-container .sub-dropdown {
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
   position: relative;
   height: 26px;
   width: auto;
-  float: right;
-  margin-right: 2%;
+  float: left;
+  /*margin-right: 2%;*/
   color: #fff;
   font-family: 'Open Sans Semibold';
   -webkit-font-smoothing: antialiased;
@@ -3192,24 +3198,25 @@ body,
   cursor: pointer;
   padding: 5px;
   padding-right: 13px;
+  padding-top: 10px;
 }
 .movie-detail .content-box .bottom-container .sub-dropdown.open {
-  background-color: rgba(22,160,133,0.6);
+  /*background-color: rgba(22,160,133,0.6);
   -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
 }
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
   width: 0;
   height: 0;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  top: 10px;
+  top: 15px;
   position: absolute;
   float: left;
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}*/
+}
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
@@ -3231,7 +3238,7 @@ body,
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-/*.movie-detail .content-box .bottom-container .flag {
+.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3242,7 +3249,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}*/
+}
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3414,15 +3421,15 @@ body,
   left: 0;
   position: absolute;
 }
-/*.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 10px;
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
   float: left;
   position: relative;
   height: 15px;
-  width: 95px;
-  left: 3%;
+  width: 125px;
+  left: 15px;
   line-height: 1;
-}*/
+}
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -5757,8 +5764,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-/*.settings-container-contain .settings-container section .title {
-  padding-bottom: 26px;
+.settings-container-contain .settings-container section .title {
+  padding-top: 26px;
   color: #16a085;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5766,7 +5773,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid #2c3e50;
-}*/
+}
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;
@@ -6650,88 +6657,4 @@ div.provider:hover{color:#fff;}
   /*margin-right: 30px;*/
   position: relative;
   /*border-right: 1px solid #3a3b3e;*/
-}
-.movie-detail .content-box .meta-container {
-  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
-  height: calc(100% - 110px);
-}
-.movie-detail .content-box .meta-container .overview {
-  position: relative;
-  height: 70%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  float: none;
-  color: #fff;
-  top: 25px;
-  padding-right: 2%;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 13px;
-  line-height: 22px;
-  text-align: justify;
-  text-shadow: 1px rgba(0,0,0,0.1);
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  overflow-x: hidden;
-  overflow-y: overlay;
-  -webkit-overflow-scrolling: touch;
-}
-.movie-detail .content-box .bottom-container {
-  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
-  height: 110px;
-  line-height: 35px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
-  position: relative;
-  height: 26px;
-  width: auto;
-  float: left;
-  /*margin-right: 2%;*/
-  color: #fff;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 12px;
-  line-height: 17px;
-  cursor: pointer;
-  padding: 5px;
-  padding-right: 13px;
-  padding-top: 10px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown.open {
-  /*background-color: rgba(36,104,204,0.6);
-  -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;*/
-}
-.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
-  width: 0;
-  height: 0;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  top: 15px;
-  position: absolute;
-  float: left;
-  right: 5px;
-  border-top: 5px solid #c4c6c8;
-  border-bottom: none;
-}
-.movie-detail .content-box .bottom-container .flag {
-  margin: 3px;
-  background-image: url("../images/flags/none.png");
-  -webkit-background-size: 24px 24px;
-  background-size: 24px 24px;
-  background-position: center;
-  position: relative;
-  float: right;
-  cursor: pointer;
-  width: 24px;
-  height: 22px;
-}
-.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 13px;
-  float: left;
-  position: relative;
-  height: 15px;
-  width: 125px;
-  left: 15px;
-  line-height: 1;
 }

--- a/src/app/themes/Official_-_Flat_UI_theme.css
+++ b/src/app/themes/Official_-_Flat_UI_theme.css
@@ -277,6 +277,7 @@ ul.nav-hor > li {
   position: absolute;
   right: 3px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #player,
 .player {
@@ -730,6 +731,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-play-control:hover:before {
   text-shadow: none !important;
@@ -766,6 +768,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-volume-control {
   top: 17px;
@@ -914,6 +917,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-fullscreen-control:hover:before {
   text-shadow: none !important;
@@ -1073,6 +1077,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_smallersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1098,6 +1103,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_biggersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1117,6 +1123,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-hidden {
   display: none;
@@ -1288,8 +1295,7 @@ ul.nav-hor > li {
   font-weight: normal;
   font-style: normal;
   font-family: Arial, sans-serif;
-  -webkit-user-select: none;
-  user-select: none;
+  -ms-user-select: none;
   -webkit-user-select: none;
   user-select: none;
 }
@@ -1574,6 +1580,7 @@ body,
   top: 16%;
   opacity: 1;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .init-progressbar {
   position: relative;
@@ -1605,6 +1612,7 @@ body,
   height: calc(11%);
   max-height: 52px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
   -webkit-transition: -webkit-filter 0.5s;
   transition: -webkit-filter 0.5s;
 }
@@ -1652,6 +1660,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: 15%;
   -webkit-transition: color 0.5s, font-family 0.5s;
@@ -1688,6 +1697,7 @@ body,
   margin: 0 auto;
   -moz-animation: spin 0.5s infinite linear;
   -webkit-animation: spin 0.5s infinite linear;
+  animation: spin 0.5s infinite linear;
 }
 .loading-container .ball1 {
   background-color: rgba(0,0,0,0);
@@ -1707,6 +1717,7 @@ body,
   top: -50px;
   -moz-animation: spinoff 0.5s infinite linear;
   -webkit-animation: spinoff 0.5s infinite linear;
+  animation: spinoff 0.5s infinite linear;
 }
 #disclaimer-container .disclaimer {
   height: 100%;
@@ -1752,6 +1763,7 @@ body,
   left: 40px;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
 }
 #disclaimer-container .disclaimer .disclaimer-state .disclaimer-content {
@@ -2007,6 +2019,7 @@ body,
   cursor: pointer;
   background: url("../images/icons/topbar_sprite_win.png");
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-close {
   background-position: -40px 0px;
@@ -2023,10 +2036,12 @@ body,
 #header .btn-set.win32 .btn-os.os-close:hover {
   background-position: -100px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover {
   background-position: -80px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover.os-is-max:hover {
   background-position: -140px 0px;
@@ -2034,6 +2049,7 @@ body,
 #header .btn-set.win32 .btn-os.os-min:hover {
   background-position: -60px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.darwin .btn-os {
   background-image: none;
@@ -2289,6 +2305,7 @@ body,
   border-radius: 10em;
   -webkit-appearance: textfield;
   -webkit-box-sizing: content-box;
+  box-sizing: content-box;
   -webkit-transition: width 0.5s;
   transition: width 0.5s;
 }
@@ -2577,6 +2594,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-favorites.selected {
@@ -2595,6 +2613,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-watched:hover {
@@ -2702,6 +2721,7 @@ body,
   float: left;
   background-color: #fff;
   -webkit-transition: background-color 200ms linear;
+  transition: background-color 200ms linear;
 }
 .load-more > .loading-container {
   display: none;
@@ -2717,6 +2737,7 @@ body,
   left: 50%;
   margin: -25px;
   -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
 }
 .load-more > .loading-container .ball1 {
   margin: -15px;
@@ -2765,6 +2786,7 @@ body,
   padding-top: 65px;
   width: 100vw;
   -webkit-user-select: none;
+  -ms-user-select: none;
   user-select: none;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
@@ -2824,9 +2846,9 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-.movie-detail .content-box .meta-container {
+/*.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
-}
+}*/
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;
@@ -2846,7 +2868,8 @@ body,
   font-size: 12px;
   position: relative;
   font-family: 'Open Sans Bold';
-  text-stroke: 1px rgba(0,0,0,0.1);
+  -webkit-text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   float: left;
   -webkit-font-smoothing: antialiased;
   max-width: 35%;
@@ -3002,10 +3025,10 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-.movie-detail .content-box .bottom-container {
+/*.movie-detail .content-box .bottom-container {
   height: 70px;
   line-height: 35px;
-}
+}*/
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3155,7 +3178,7 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-.movie-detail .content-box .bottom-container .sub-dropdown {
+/*.movie-detail .content-box .bottom-container .sub-dropdown {
   position: relative;
   height: 26px;
   width: auto;
@@ -3186,30 +3209,29 @@ body,
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}
+}*/
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
 }
 .movie-detail .content-box .bottom-container .flag-container {
-  position: absolute;
+  position: relative;
   margin-right: 5.2%;
-  margin-top: 26px;
+  margin-top: 13px;
   z-index: 3;
   width: auto;
-  max-width: 330px;
+  max-width: 165px;
   max-height: 72px;
-  right: 0;
-  overflow-x: hidden;
-  overflow-y: hidden;
   display: none;
   height: auto;
   background: rgba(20,24,26,0.6);
+  float:left;
+  overflow:auto;
 }
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-.movie-detail .content-box .bottom-container .flag {
+/*.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3220,7 +3242,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}
+}*/
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3392,7 +3414,7 @@ body,
   left: 0;
   position: absolute;
 }
-.movie-detail .content-box .bottom-container .movie-quality-container {
+/*.movie-detail .content-box .bottom-container .movie-quality-container {
   margin-top: 10px;
   float: left;
   position: relative;
@@ -3400,7 +3422,7 @@ body,
   width: 95px;
   left: 3%;
   line-height: 1;
-}
+}*/
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -5735,8 +5757,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-.settings-container-contain .settings-container section .title {
-  padding-top: 26px;
+/*.settings-container-contain .settings-container section .title {
+  padding-bottom: 26px;
   color: #16a085;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5744,7 +5766,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid #2c3e50;
-}
+}*/
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;
@@ -6300,6 +6322,7 @@ body,
   right: 0;
   padding-top: 32px;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .loading .loading-background {
   position: absolute;
@@ -6330,6 +6353,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: calc(50% - 180px);
 }
@@ -6407,6 +6431,7 @@ body,
   background-clip: padding-box;
   background-color: #1abc9c;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
@@ -6421,6 +6446,7 @@ body,
 }
 .loading .state .cancel-button .cancel-button-text {
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   color: #fff;
   font-family: 'Open Sans Semibold', 'Open Sans', sans-serif;
@@ -6572,4 +6598,140 @@ body,
 #notification .notification p {
   font-weight: 100;
   line-height: 20px;
+}
+
+.about-container .content .icons_social a.github_icon {
+  background: url("../images/icons/icon-github.png") no-repeat center;
+  -webkit-background-size: contain;
+  background-size: contain;
+}
+.settings-container-contain .settings-container #connection .reset-ytsAPI {
+  font-size: 13px;
+  color: #8a8b8e;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+.settings-container-contain .settings-container #connection .reset-ytsAPI:hover {
+  cursor: pointer;
+  color: #2468cc;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar {
+  width: 5px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-track {
+  background-color: #30333c;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-thumb {
+  background-color: #83888c;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-thumb:hover {
+  background-color: #93989c;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-resizer,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-corner,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-button,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-track-piece {
+  display: none;
+}
+div.provider{cursor:pointer; float:left; margin-right:5px;}
+div.provider:hover{color:#fff;}
+.settings-container-contain .settings-container section .title {
+  padding-bottom: 26px;
+  color: #2d75df;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 17px;
+  width: 160px;
+  /*margin-right: 30px;*/
+  position: relative;
+  /*border-right: 1px solid #3a3b3e;*/
+}
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
+.movie-detail .content-box .meta-container .overview {
+  position: relative;
+  height: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  float: none;
+  color: #fff;
+  top: 25px;
+  padding-right: 2%;
+  font-family: 'Open Sans Semibold';
+  -webkit-font-smoothing: antialiased;
+  font-size: 13px;
+  line-height: 22px;
+  text-align: justify;
+  text-shadow: 1px rgba(0,0,0,0.1);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  overflow-x: hidden;
+  overflow-y: overlay;
+  -webkit-overflow-scrolling: touch;
+}
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
+  line-height: 35px;
+}
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
+  position: relative;
+  height: 26px;
+  width: auto;
+  float: left;
+  /*margin-right: 2%;*/
+  color: #fff;
+  font-family: 'Open Sans Semibold';
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 17px;
+  cursor: pointer;
+  padding: 5px;
+  padding-right: 13px;
+  padding-top: 10px;
+}
+.movie-detail .content-box .bottom-container .sub-dropdown.open {
+  /*background-color: rgba(36,104,204,0.6);
+  -webkit-border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
+}
+.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  top: 15px;
+  position: absolute;
+  float: left;
+  right: 5px;
+  border-top: 5px solid #c4c6c8;
+  border-bottom: none;
+}
+.movie-detail .content-box .bottom-container .flag {
+  margin: 3px;
+  background-image: url("../images/flags/none.png");
+  -webkit-background-size: 24px 24px;
+  background-size: 24px 24px;
+  background-position: center;
+  position: relative;
+  float: right;
+  cursor: pointer;
+  width: 24px;
+  height: 22px;
+}
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
+  float: left;
+  position: relative;
+  height: 15px;
+  width: 125px;
+  left: 15px;
+  line-height: 1;
 }

--- a/src/app/themes/Official_-_Light_theme.css
+++ b/src/app/themes/Official_-_Light_theme.css
@@ -2846,9 +2846,14 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-/*.movie-detail .content-box .meta-container {
+/*
+.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
 }*/
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;

--- a/src/app/themes/Official_-_Light_theme.css
+++ b/src/app/themes/Official_-_Light_theme.css
@@ -277,6 +277,7 @@ ul.nav-hor > li {
   position: absolute;
   right: 3px;
   -webkit-filter: brightness(0.3);
+  filter: brightness(0.3);
 }
 #player,
 .player {
@@ -730,6 +731,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-play-control:hover:before {
   text-shadow: none !important;
@@ -766,6 +768,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-volume-control {
   top: 17px;
@@ -914,6 +917,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-fullscreen-control:hover:before {
   text-shadow: none !important;
@@ -1073,6 +1077,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs_smallersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1098,6 +1103,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(1);
 }
 .vjs-popcorn-skin .vjs_biggersub_button.vjs-control:hover:before {
   text-shadow: none;
@@ -1117,6 +1123,7 @@ ul.nav-hor > li {
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
   -webkit-filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 .vjs-popcorn-skin .vjs-hidden {
   display: none;
@@ -1288,8 +1295,7 @@ ul.nav-hor > li {
   font-weight: normal;
   font-style: normal;
   font-family: Arial, sans-serif;
-  -webkit-user-select: none;
-  user-select: none;
+  -ms-user-select: none;
   -webkit-user-select: none;
   user-select: none;
 }
@@ -1574,6 +1580,7 @@ body,
   top: 16%;
   opacity: 1;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .init-progressbar {
   position: relative;
@@ -1605,6 +1612,7 @@ body,
   height: calc(11%);
   max-height: 52px;
   -webkit-filter: brightness(0.3);
+  filter: brightness(0.3);
   -webkit-transition: -webkit-filter 0.5s;
   transition: -webkit-filter 0.5s;
 }
@@ -1652,6 +1660,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: 15%;
   -webkit-transition: color 0.5s, font-family 0.5s;
@@ -1688,6 +1697,7 @@ body,
   margin: 0 auto;
   -moz-animation: spin 0.5s infinite linear;
   -webkit-animation: spin 0.5s infinite linear;
+  animation: spin 0.5s infinite linear;
 }
 .loading-container .ball1 {
   background-color: rgba(0,0,0,0);
@@ -1707,6 +1717,7 @@ body,
   top: -50px;
   -moz-animation: spinoff 0.5s infinite linear;
   -webkit-animation: spinoff 0.5s infinite linear;
+  animation: spinoff 0.5s infinite linear;
 }
 #disclaimer-container .disclaimer {
   height: 100%;
@@ -1752,6 +1763,7 @@ body,
   left: 40px;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
 }
 #disclaimer-container .disclaimer .disclaimer-state .disclaimer-content {
@@ -2007,6 +2019,7 @@ body,
   cursor: pointer;
   background: url("../images/icons/topbar_sprite_win.png");
   -webkit-filter: brightness(0.3);
+ filter: brightness(0.3);
 }
 #header .btn-set.win32 .btn-os.os-close {
   background-position: -40px 0px;
@@ -2023,10 +2036,12 @@ body,
 #header .btn-set.win32 .btn-os.os-close:hover {
   background-position: -100px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover {
   background-position: -80px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.win32 .btn-os.os-max:hover.os-is-max:hover {
   background-position: -140px 0px;
@@ -2034,6 +2049,7 @@ body,
 #header .btn-set.win32 .btn-os.os-min:hover {
   background-position: -60px 0px;
   -webkit-filter: brightness(1);
+  filter: brightness(1);
 }
 #header .btn-set.darwin .btn-os {
   background-image: none;
@@ -2289,6 +2305,7 @@ body,
   border-radius: 10em;
   -webkit-appearance: textfield;
   -webkit-box-sizing: content-box;
+  box-sizing: content-box;
   -webkit-transition: width 0.5s;
   transition: width 0.5s;
 }
@@ -2577,6 +2594,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-favorites.selected {
@@ -2595,6 +2613,7 @@ body,
   color: #fff;
   font-size: 1.4em;
   -webkit-transition: all 0.5s;
+  transition: all 0.5s;
   opacity: 0.3;
 }
 .item .cover .cover-overlay .actions-watched:hover {
@@ -2702,6 +2721,7 @@ body,
   float: left;
   background-color: #f8f8f8;
   -webkit-transition: background-color 200ms linear;
+  transition: background-color 200ms linear;
 }
 .load-more > .loading-container {
   display: none;
@@ -2717,6 +2737,7 @@ body,
   left: 50%;
   margin: -25px;
   -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
 }
 .load-more > .loading-container .ball1 {
   margin: -15px;
@@ -2765,6 +2786,7 @@ body,
   padding-top: 65px;
   width: 100vw;
   -webkit-user-select: none;
+  -ms-user-select: none;
   user-select: none;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
@@ -2824,9 +2846,9 @@ body,
   width: 65vw;
   padding-right: 4vw;
 }
-.movie-detail .content-box .meta-container {
+/*.movie-detail .content-box .meta-container {
   height: calc(100% - 70px);
-}
+}*/
 .movie-detail .content-box .meta-container .title {
   color: #fff;
   position: relative;
@@ -2846,7 +2868,8 @@ body,
   font-size: 12px;
   position: relative;
   font-family: 'Open Sans Bold';
-  text-stroke: 1px rgba(0,0,0,0.1);
+  -webkit-text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   float: left;
   -webkit-font-smoothing: antialiased;
   max-width: 35%;
@@ -2973,7 +2996,7 @@ body,
   font-size: 13px;
   line-height: 22px;
   text-align: justify;
-  text-stroke: 1px rgba(0,0,0,0.1);
+  text-shadow: 1px rgba(0,0,0,0.1);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   overflow-x: hidden;
@@ -3002,10 +3025,10 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-.movie-detail .content-box .bottom-container {
+/*.movie-detail .content-box .bottom-container {
   height: 70px;
   line-height: 35px;
-}
+}*/
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3155,7 +3178,7 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-.movie-detail .content-box .bottom-container .sub-dropdown {
+/*.movie-detail .content-box .bottom-container .sub-dropdown {
   position: relative;
   height: 26px;
   width: auto;
@@ -3180,36 +3203,35 @@ body,
   height: 0;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  top: 10px;
+  top: 15px;
   position: absolute;
   float: left;
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}
+}*/
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
 }
 .movie-detail .content-box .bottom-container .flag-container {
-  position: absolute;
+  position: relative;
   margin-right: 5.2%;
-  margin-top: 26px;
+  margin-top: 13px;
   z-index: 3;
   width: auto;
-  max-width: 330px;
+  max-width: 165px;
   max-height: 72px;
-  right: 0;
-  overflow-x: hidden;
-  overflow-y: hidden;
   display: none;
   height: auto;
   background: rgba(20,24,26,0.6);
+  float:left;
+  overflow:auto;
 }
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-.movie-detail .content-box .bottom-container .flag {
+/*.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3220,7 +3242,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}
+}*/
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3392,15 +3414,15 @@ body,
   left: 0;
   position: absolute;
 }
-.movie-detail .content-box .bottom-container .movie-quality-container {
+/*.movie-detail .content-box .bottom-container .movie-quality-container {
   margin-top: 10px;
   float: left;
   position: relative;
   height: 15px;
-  width: 95px;
-  left: 3%;
+  width: 125px;
+  left: 15px;
   line-height: 1;
-}
+}*/
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -5735,8 +5757,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-.settings-container-contain .settings-container section .title {
-  padding-top: 26px;
+/*.settings-container-contain .settings-container section .title {
+  padding-bottom: 26px;
   color: #008f00;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5744,7 +5766,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid #aaa;
-}
+}*/
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;
@@ -6300,6 +6322,7 @@ body,
   right: 0;
   padding-top: 32px;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 .loading .loading-background {
   position: absolute;
@@ -6330,6 +6353,7 @@ body,
   left: 0;
   right: 0;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   top: calc(50% - 180px);
 }
@@ -6407,6 +6431,7 @@ body,
   background-clip: padding-box;
   background-color: #00a300;
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
@@ -6421,6 +6446,7 @@ body,
 }
 .loading .state .cancel-button .cancel-button-text {
   -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   position: relative;
   color: #fff;
   font-family: 'Open Sans Semibold', 'Open Sans', sans-serif;
@@ -6572,4 +6598,140 @@ body,
 #notification .notification p {
   font-weight: 100;
   line-height: 20px;
+}
+
+.about-container .content .icons_social a.github_icon {
+  background: url("../images/icons/icon-github.png") no-repeat center;
+  -webkit-background-size: contain;
+  background-size: contain;
+}
+.settings-container-contain .settings-container #connection .reset-ytsAPI {
+  font-size: 13px;
+  color: #8a8b8e;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+.settings-container-contain .settings-container #connection .reset-ytsAPI:hover {
+  cursor: pointer;
+  color: #2468cc;
+  -webkit-transition: all 0.5s;
+  transition: all 0.5s;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar {
+  width: 5px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-track {
+  background-color: #30333c;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-thumb {
+  background-color: #83888c;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-thumb:hover {
+  background-color: #93989c;
+}
+.movie-detail .content-box .bottom-container .flag-container::-webkit-resizer,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-corner,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-button,
+.movie-detail .content-box .bottom-container .flag-container::-webkit-scrollbar-track-piece {
+  display: none;
+}
+div.provider{cursor:pointer; float:left; margin-right:5px;}
+div.provider:hover{color:#fff;}
+.settings-container-contain .settings-container section .title {
+  padding-bottom: 26px;
+  color: #2d75df;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 17px;
+  width: 160px;
+  /*margin-right: 30px;*/
+  position: relative;
+  /*border-right: 1px solid #3a3b3e;*/
+}
+.movie-detail .content-box .meta-container {
+  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
+  height: calc(100% - 110px);
+}
+.movie-detail .content-box .meta-container .overview {
+  position: relative;
+  height: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  float: none;
+  color: #fff;
+  top: 25px;
+  padding-right: 2%;
+  font-family: 'Open Sans Semibold';
+  -webkit-font-smoothing: antialiased;
+  font-size: 13px;
+  line-height: 22px;
+  text-align: justify;
+  text-shadow: 1px rgba(0,0,0,0.1);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  overflow-x: hidden;
+  overflow-y: overlay;
+  -webkit-overflow-scrolling: touch;
+}
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
+  line-height: 35px;
+}
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
+  position: relative;
+  height: 26px;
+  width: auto;
+  float: left;
+  /*margin-right: 2%;*/
+  color: #fff;
+  font-family: 'Open Sans Semibold';
+  -webkit-font-smoothing: antialiased;
+  font-size: 12px;
+  line-height: 17px;
+  cursor: pointer;
+  padding: 5px;
+  padding-right: 13px;
+  padding-top: 10px;
+}
+.movie-detail .content-box .bottom-container .sub-dropdown.open {
+  /*background-color: rgba(36,104,204,0.6);
+  -webkit-border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
+}
+.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  top: 15px;
+  position: absolute;
+  float: left;
+  right: 5px;
+  border-top: 5px solid #c4c6c8;
+  border-bottom: none;
+}
+.movie-detail .content-box .bottom-container .flag {
+  margin: 3px;
+  background-image: url("../images/flags/none.png");
+  -webkit-background-size: 24px 24px;
+  background-size: 24px 24px;
+  background-position: center;
+  position: relative;
+  float: right;
+  cursor: pointer;
+  width: 24px;
+  height: 22px;
+}
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
+  float: left;
+  position: relative;
+  height: 15px;
+  width: 125px;
+  left: 15px;
+  line-height: 1;
 }

--- a/src/app/themes/Official_-_Light_theme.css
+++ b/src/app/themes/Official_-_Light_theme.css
@@ -1602,7 +1602,7 @@ body,
 }
 .icon-begin {
   display: block;
-  margin: -7px auto;
+  margin: 0px auto;
   height: calc(58%);
   max-height: 256px;
 }
@@ -2085,7 +2085,7 @@ body,
   height: 28px;
   position: absolute;
   top: -6px;
-  left: calc(50% + 52px);
+  left: calc(50% + 64px);
   display: none;
 }
 .events.img-newyear {
@@ -2984,7 +2984,7 @@ body,
 }
 .movie-detail .content-box .meta-container .overview {
   position: relative;
-  height: 55%;
+  height: 70%;
   overflow: hidden;
   text-overflow: ellipsis;
   float: none;
@@ -3025,10 +3025,11 @@ body,
 .movie-detail .content-box .meta-container .overview::-webkit-scrollbar-track-piece {
   display: none;
 }
-/*.movie-detail .content-box .bottom-container {
-  height: 70px;
+.movie-detail .content-box .bottom-container {
+  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
+  height: 110px;
   line-height: 35px;
-}*/
+}
 .movie-detail .content-box .bottom-container .favourites-toggle {
   cursor: pointer;
   padding: 5px;
@@ -3178,12 +3179,12 @@ body,
 .movie-detail .content-box .bottom-container .watched-toggle.selected:hover:after {
   opacity: 1;
 }
-/*.movie-detail .content-box .bottom-container .sub-dropdown {
+.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
   position: relative;
   height: 26px;
   width: auto;
-  float: right;
-  margin-right: 2%;
+  float: left;
+  /*margin-right: 2%;*/
   color: #fff;
   font-family: 'Open Sans Semibold';
   -webkit-font-smoothing: antialiased;
@@ -3192,11 +3193,12 @@ body,
   cursor: pointer;
   padding: 5px;
   padding-right: 13px;
+  padding-top: 10px;
 }
 .movie-detail .content-box .bottom-container .sub-dropdown.open {
-  background-color: rgba(0,143,0,0.6);
+  /*background-color: rgba(0,143,0,0.6);
   -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;
+  border-radius: 5px 5px 0 0;*/
 }
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
   width: 0;
@@ -3209,7 +3211,7 @@ body,
   right: 5px;
   border-top: 5px solid #c4c6c8;
   border-bottom: none;
-}*/
+}
 .movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow.down {
   border-bottom: 5px solid #c4c6c8;
   border-top: none;
@@ -3231,7 +3233,7 @@ body,
 .movie-detail .content-box .bottom-container .flag-container .flag {
   height: 16px;
 }
-/*.movie-detail .content-box .bottom-container .flag {
+.movie-detail .content-box .bottom-container .flag {
   margin: 3px;
   background-image: url("../images/flags/none.png");
   -webkit-background-size: 24px 24px;
@@ -3242,7 +3244,7 @@ body,
   cursor: pointer;
   width: 24px;
   height: 22px;
-}*/
+}
 .movie-detail .content-box .bottom-container .flag.NA {
   background-image: url("../images/flags/none.png");
 }
@@ -3414,15 +3416,15 @@ body,
   left: 0;
   position: absolute;
 }
-/*.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 10px;
+.movie-detail .content-box .bottom-container .movie-quality-container {
+  margin-top: 13px;
   float: left;
   position: relative;
   height: 15px;
   width: 125px;
   left: 15px;
   line-height: 1;
-}*/
+}
 .movie-detail .content-box .bottom-container .movie-quality-container .tooltip {
   width: 85px;
 }
@@ -5757,8 +5759,8 @@ body,
   position: relative;
 /* overlay styles, all needed */
 }
-/*.settings-container-contain .settings-container section .title {
-  padding-bottom: 26px;
+.settings-container-contain .settings-container section .title {
+  padding-top: 26px;
   color: #008f00;
   font-family: 'Open Sans', sans-serif;
   font-size: 17px;
@@ -5766,7 +5768,7 @@ body,
   margin-right: 30px;
   position: relative;
   border-right: 1px solid #aaa;
-}*/
+}
 .settings-container-contain .settings-container section .content {
   position: relative;
   padding-top: 30px;
@@ -6650,88 +6652,4 @@ div.provider:hover{color:#fff;}
   /*margin-right: 30px;*/
   position: relative;
   /*border-right: 1px solid #3a3b3e;*/
-}
-.movie-detail .content-box .meta-container {
-  /*be carefull - dependent on .movie-detail .content-box .bottom-container*/
-  height: calc(100% - 110px);
-}
-.movie-detail .content-box .meta-container .overview {
-  position: relative;
-  height: 70%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  float: none;
-  color: #fff;
-  top: 25px;
-  padding-right: 2%;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 13px;
-  line-height: 22px;
-  text-align: justify;
-  text-shadow: 1px rgba(0,0,0,0.1);
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  overflow-x: hidden;
-  overflow-y: overlay;
-  -webkit-overflow-scrolling: touch;
-}
-.movie-detail .content-box .bottom-container {
-  /*be carefull - dependent on .movie-detail .content-box .meta-container*/
-  height: 110px;
-  line-height: 35px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown {/*subtitles*/
-  position: relative;
-  height: 26px;
-  width: auto;
-  float: left;
-  /*margin-right: 2%;*/
-  color: #fff;
-  font-family: 'Open Sans Semibold';
-  -webkit-font-smoothing: antialiased;
-  font-size: 12px;
-  line-height: 17px;
-  cursor: pointer;
-  padding: 5px;
-  padding-right: 13px;
-  padding-top: 10px;
-}
-.movie-detail .content-box .bottom-container .sub-dropdown.open {
-  /*background-color: rgba(36,104,204,0.6);
-  -webkit-border-radius: 5px 5px 0 0;
-  border-radius: 5px 5px 0 0;*/
-}
-.movie-detail .content-box .bottom-container .sub-dropdown .sub-dropdown-arrow {
-  width: 0;
-  height: 0;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  top: 15px;
-  position: absolute;
-  float: left;
-  right: 5px;
-  border-top: 5px solid #c4c6c8;
-  border-bottom: none;
-}
-.movie-detail .content-box .bottom-container .flag {
-  margin: 3px;
-  background-image: url("../images/flags/none.png");
-  -webkit-background-size: 24px 24px;
-  background-size: 24px 24px;
-  background-position: center;
-  position: relative;
-  float: right;
-  cursor: pointer;
-  width: 24px;
-  height: 22px;
-}
-.movie-detail .content-box .bottom-container .movie-quality-container {
-  margin-top: 13px;
-  float: left;
-  position: relative;
-  height: 15px;
-  width: 125px;
-  left: 15px;
-  line-height: 1;
 }


### PR DESCRIPTION
- The Official themes all contained CSS errors causing the "Subtitles"
  text and flags to appear incorrectly. Only the "Dark" theme was correct.
- First pass at cleaning up the themes removing unneeded lines, and
  duplicate entries.
