### PR TITLE
Fix Chromecast to support v.0.1.8 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "adm-zip": "0.4.7",
     "airplay-js": "^0.2.16",
     "async": "0.9.0",
-    "chromecast-js": "^0.1.7",
+    "chromecast-js": "git+https://github.com/captainyarr/chromecast-js.git",
     "gitlab": "1.3.0",
     "i18n": "0.5.0",
     "iconv-lite": "^0.4.7",


### PR DESCRIPTION
Updated to Chromecast-js to version v0.1.8 to match current version used in PTCE v3.9.
- New repo created for v0.1.8
- Updated Package to pull from new git repo [Chromecast-js](https://github.com/captainyarr/chromecast-js)
