### PR TITLE
Fixed Kat API and Strike API implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "iconv-lite": "^0.4.7",
     "jschardet": "1.1.1",
     "json-rpc2": "^0.8.1",
-    "kat-api": "git+https://github.com/PopcornTime-CE/kat-api.git",
+    "kat-api-ce": "^0.0.4",
     "markdown": "~0.5.0",
     "memoizee": "^0.3.8",
     "mkdirp": "*",


### PR DESCRIPTION
kat-api-ce:
- Update package.json to use npm kat-api-ce so that it is shared across ptce projects.
- Update kat api category value to match api needs.

strike-api:
- Update category value to match api
- Strike API removed the magnet_uri so added a function to create magnet_uri from torrent hash
- Fixed magnet uri field
- Add additional checks to handle 0 results returned. Throws appropriate error and handled correctly.
