### PR TITLE
FIX: MPV player was not working due to old command-line parameters.

### DIFF
--- a/src/app/lib/device/ext-player.js
+++ b/src/app/lib/device/ext-player.js
@@ -128,8 +128,8 @@
         },
         'mpv': {
             type: 'mpv',
-            switches: '--no-terminal',
-            subswitch: '--sub-file=',
+            switches: '',
+            subswitch: '--sub=',
             fs: '--fs'
         },
         'MPC-HC': {


### PR DESCRIPTION
- Updated the command-line options to reflect latest version.
- Removed '--no-terminal' option.
- Changed '--sub-file=' to '--sub=' as per latest version.
