### PR TITLE
FIX: Crash when leaving Favorites view

### DIFF
--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -90,7 +90,11 @@
         },
 
         onDestroy: function () {
-            this.ui.coverImage.off('load');
+            try {
+                this.ui.coverImage.off('load');
+            } catch (err) {
+                win.error(err);
+            }
         },
 
         hoverItem: function (e) {


### PR DESCRIPTION
- Updated the onDestroy function to handle uncaught exceptions.  
- Leaving favorite page would generate exception error causing the app to hang indefinitely.
