### PR TITLE
FIX #90: Limit title length to avoid scrollbar

### DIFF
--- a/src/app/lib/device/chromecast.js
+++ b/src/app/lib/device/chromecast.js
@@ -26,6 +26,7 @@
             var subtitle = streamModel.get('subFile');
             var cover = streamModel.get('cover');
             var url = streamModel.get('src');
+            var title = streamModel.get('title').substring(0,50);
             this.attributes.url = url;
             var media;
 
@@ -38,7 +39,7 @@
                         language: 'en-US'
                     }],
                     cover: {
-                        title: streamModel.get('title'),
+                        title: title,
                         url: streamModel.get('cover')
                     },
                     subtitles_style: {
@@ -59,7 +60,7 @@
                 media = {
                     url: url,
                     cover: {
-                        title: streamModel.get('title'),
+                        title: title,
                         url: streamModel.get('cover')
                     }
                 };


### PR DESCRIPTION
Chromecast broke the truncation in the latest firmware update. Causing to appear a scroll bar in the bottom of the screen. Limiting the title length when sending to cast fixes the issue.
[google-cast-sdk discussion](https://code.google.com/p/google-cast-sdk/issues/detail?id=781)
