### PR TITLE
nwjs binary updated to latest to fix segment fault on macOS Sierra

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var del = require('del');
 var detectCurrentPlatform = require('nw-builder/lib/detectCurrentPlatform.js');
 var nw = new NwBuilder({
     files: ['./src/**', './node_modules/**', './package.json'],
-    version: '0.12.3',
+    version: '0.18.0',
     platforms: argv.p ? argv.p.split(',') : [detectCurrentPlatform()]
 }).on('log', console.log);
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "url": "https://github.com/PopcornTimeCommunity/desktop.git"
   },
   "license": "GPL-3.0",
-  "main": "app://host/src/app/index.html",
+  "main": "src/app/index.html",
   "version": "0.4.1-1",
-  "node-remote": "client.vpn.ht",
+  "node-remote": "*://*",
   "releaseName": "Give me some Nachos",
   "scripts": {
     "start": "gulp run"


### PR DESCRIPTION
This PR will resolve #105 and #106 . I investigated the issue and it was most probably a segfault and the latest version of nwjs fixes that. I reached at that conclusion because `exited with code 11` usually refers to a segment fault so I went ahead and tested with [Node Segment fault handler](https://github.com/ddopson/node-segfault-handler) and that indeed was the issue. It'll be very hard to actually try to track the issue down and fix while staying with this **very** outdated version of nwjs and in my opinion, future is the way to go.
