### PR TITLE
FIX: Nacholink Cancel button not working

### DIFF
--- a/src/app/lib/device/nacholink.js
+++ b/src/app/lib/device/nacholink.js
@@ -3,7 +3,9 @@
     'use strict';
     var collection = App.Device.Collection;
 
-   var Airplay = App.Device.Generic.extend();
+   var Airplay = App.Device.Generic.extend({
+	   stop: function () {},
+   });
 
     //if (this.model.get('google_video')) {
 	collection.add(new Airplay({


### PR DESCRIPTION
- Cancel button was not working when trying to cancel a nacholink stream forcing the user to close and re-open the app.