### PR TITLE
Fixing the JS error causing "stream:start" event to not be bound

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,18 @@
   "window": {
     "title": "Popcorn Time CE",
     "icon": "src/app/images/icon.png",
-    "toolbar": false,
-    "frame": false,
+    "toolbar": true,
+    "frame": true,
     "min_width": 960,
     "min_height": 520,
     "resizable": true,
-    "show": false,
+    "show": true,
     "position": "center"
   },
+  "peerDependencies": {
+    "simple-get": "2.2.5"
+  },
   "dependencies": {
-    "urijs": "^1.17.0",
     "adm-zip": "0.4.7",
     "airplay-js": "^0.2.16",
     "async": "0.9.0",
@@ -59,6 +61,7 @@
     "sanitizer": "^0.1.2",
     "semver": "^4.3.3",
     "send": "0.12.2",
+    "simple-get": "2.2.5",
     "strike-api": "0.2.0",
     "tar": "^1.0.3",
     "temp": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "window": {
     "title": "Popcorn Time CE",
     "icon": "src/app/images/icon.png",
-    "toolbar": true,
-    "frame": true,
+    "toolbar": false,
+    "frame": false,
     "min_width": 960,
     "min_height": 520,
     "resizable": true,
-    "show": true,
+    "show": false,
     "position": "center"
   },
   "peerDependencies": {


### PR DESCRIPTION
After some debugging, the "stream:start" event that launches the player was not bound to the App.vent namespace.  It was due to a JS error caused by a library "unzip-response" which contained ES6 arrow functions not supported by the current requirement of NWJS 0.12.3.  The "unzip-response" module was used by "simple-get" which is used by a chain of other modules.  To mitigate this issue, I decided to tighten the versions to make sure what is being required is ES5 friendly hence fixing the JS error and allowing the "stream:start" event to be bound.  Phew... anyway, it's a small change and it works fine.