### PR TITLE
Fixing the JS error causing "stream:start" event to not be bound 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "show": false,
     "position": "center"
   },
+  "peerDependencies": {
+    "simple-get": "2.2.5"
+  },
   "dependencies": {
     "urijs": "^1.17.0",
     "adm-zip": "0.4.7",
@@ -59,6 +62,7 @@
     "sanitizer": "^0.1.2",
     "semver": "^4.3.3",
     "send": "0.12.2",
+    "simple-get": "2.2.5",
     "strike-api": "0.2.0",
     "tar": "^1.0.3",
     "temp": "^0.8.1",


### PR DESCRIPTION
After some debugging, the "stream:start" event that launches the player was not bound to the App.vent namespace. It was due to a JS error caused by a library "unzip-response" which contained ES6 arrow functions not supported by the current requirement of NWJS 0.12.3. The "unzip-response" module was used by "simple-get" which is used by a chain of other modules. To mitigate this issue, I decided to tighten the versions to make sure what is being required is ES5 friendly hence fixing the JS error and allowing the "stream:start" event to be bound. Phew... anyway, it's a small change and it works fine.