### PR TITLE
MPV: fix subtitles options

### DIFF
--- a/src/app/lib/device/ext-player.js
+++ b/src/app/lib/device/ext-player.js
@@ -129,7 +129,7 @@
         'mpv': {
             type: 'mpv',
             switches: '',
-            subswitch: '--sub=',
+            subswitch: '--sub-file=',
             fs: '--fs'
         },
         'MPC-HC': {


### PR DESCRIPTION
Apparently some time ago `mpv` changed it's subtitle flag from `sub-file` to `sub`, but on the current version (v0.27) it went back to being `sub-file`.
This PR changes back the subswitch for mpv to the current accepted flag.